### PR TITLE
fix terminate on chld signal

### DIFF
--- a/src/jamrouter.c
+++ b/src/jamrouter.c
@@ -380,9 +380,9 @@ jamrouter_signal_handler(int i)
 int
 init_signal_handlers(void)
 {
-	int                 signals[14] = {
+	int                 signals[13] = {
 		SIGHUP,  SIGINT,  SIGQUIT, SIGILL,  SIGABRT, SIGFPE,  SIGSEGV,
-		SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2, SIGCHLD, 0
+		SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2, 0
 	};
 	struct sigaction    action;
 	int                 j;

--- a/src/jamrouter.c
+++ b/src/jamrouter.c
@@ -380,9 +380,8 @@ jamrouter_signal_handler(int i)
 int
 init_signal_handlers(void)
 {
-	int                 signals[13] = {
-		SIGHUP,  SIGINT,  SIGQUIT, SIGILL,  SIGABRT, SIGFPE,  SIGSEGV,
-		SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2, 0
+	int                 signals[4] = {
+		SIGHUP,  SIGINT, SIGTERM, 0
 	};
 	struct sigaction    action;
 	int                 j;


### PR DESCRIPTION
For some reason on my system (current arch linux), jamrouter receives a chld signal on startup and terminates immediately.

Posix convention is to ignore child signals, so I removed it from the list and now it works just fine.

For more information, please see the table in this wikipedia entry:

https://en.wikipedia.org/wiki/Unix_signal#POSIX_signals

Perhaps the signals marked as "terminate and dump core" should be removed from the handler as well, in order to let the core dump take place.